### PR TITLE
Added always show self and preventing cache change

### DIFF
--- a/LMeter/ACT/ACTEvent.cs
+++ b/LMeter/ACT/ACTEvent.cs
@@ -62,11 +62,11 @@ namespace LMeter.ACT
         private static readonly Random _rand = new Random();
         
         [JsonIgnore]
-        private static readonly Dictionary<string, FieldInfo> _fields = typeof(Encounter).GetFields().ToDictionary((x) => x.Name.ToLower());
+        private static readonly Dictionary<string, MemberInfo> _members = typeof(Encounter).GetMembers().ToDictionary((x) => x.Name.ToLower());
 
         public string GetFormattedString(string format, string numberFormat)
         {
-            return TextTagFormatter.TextTagRegex.Replace(format, new TextTagFormatter(this, numberFormat, _fields).Evaluate);
+            return TextTagFormatter.TextTagRegex.Replace(format, new TextTagFormatter(this, numberFormat, _members).Evaluate);
         }
 
         [JsonProperty("title")]
@@ -131,15 +131,20 @@ namespace LMeter.ACT
         private static readonly Random _rand = new Random();
 
         [JsonIgnore]
-        private static readonly Dictionary<string, FieldInfo> _fields = typeof(Combatant).GetFields().ToDictionary((x) => x.Name.ToLower());
+        private static readonly Dictionary<string, MemberInfo> _members = typeof(Combatant).GetMembers().ToDictionary((x) => x.Name.ToLower());
 
         public string GetFormattedString(string format, string numberFormat)
         {
-            return TextTagFormatter.TextTagRegex.Replace(format, new TextTagFormatter(this, numberFormat, _fields).Evaluate);
+            return TextTagFormatter.TextTagRegex.Replace(format, new TextTagFormatter(this, numberFormat, _members).Evaluate);
         }
 
         [JsonProperty("name")]
-        public string Name = string.Empty;
+        public string OriginalName = string.Empty;
+
+        [JsonProperty("nameOverwrite")] 
+        public string? NameOverwrite = null;
+
+        public string Name => NameOverwrite ?? OriginalName;
 
         [JsonIgnore]
         public LazyString<string?>? Name_First;
@@ -262,7 +267,7 @@ namespace LMeter.ACT
 
             return new Combatant()
             {
-                Name = "Firstname Lastname",
+                OriginalName = "Firstname Lastname",
                 Duration = "00:30",
                 Job = Enum.Parse<Job>(jobs[_rand.Next(jobs.Length)]),
                 DamageTotal = new LazyFloat(damage.ToString()),

--- a/LMeter/Config/BarConfig.cs
+++ b/LMeter/Config/BarConfig.cs
@@ -41,6 +41,7 @@ namespace LMeter.Config
         public ConfigColor RankTextOutlineColor = new ConfigColor(0, 0, 0, 0.5f);
         public string RankTextFontKey = FontsManager.DalamudFontKey;
         public int RankTextFontId = 0;
+        public bool AlwaysShowSelf = false;
 
         public string LeftTextFormat = "[name]";
         public Vector2 LeftTextOffset = new Vector2(0, 0);
@@ -121,13 +122,12 @@ namespace LMeter.Config
 
             using (FontsManager.PushFont(this.BarNameFontKey))
             {
-                string playerName = Singletons.Get<IClientState>().LocalPlayer?.Name.ToString() ?? "YOU";
-                if (this.UseCharacterName && combatant.Name.Contains("YOU"))
+                var leftText = combatant.Name;
+                if (!leftText.Contains("YOU"))
                 {
-                    combatant.Name = playerName;
+                    leftText = combatant.GetFormattedString($" {this.LeftTextFormat} ", this.ThousandsSeparators ? "N" : "F");
                 }
 
-                string leftText = combatant.GetFormattedString($" {this.LeftTextFormat} ", this.ThousandsSeparators ? "N" : "F");
                 Vector2 nameTextSize = ImGui.CalcTextSize(leftText);
                 Vector2 namePos = Utils.GetAnchoredPosition(localPos, -barSize, DrawAnchor.Left);
                 namePos = Utils.GetAnchoredPosition(namePos, nameTextSize, DrawAnchor.Left) + this.LeftTextOffset;
@@ -250,6 +250,7 @@ namespace LMeter.Config
 
                 ImGui.NewLine();
                 ImGui.Checkbox("Use your name instead of 'YOU'", ref this.UseCharacterName);
+                ImGui.Checkbox("Always show your own bar", ref this.AlwaysShowSelf);
                 ImGui.InputText("Left Text Format", ref this.LeftTextFormat, 128);
 
                 if (ImGui.IsItemHovered())

--- a/LMeter/Helpers/Extensions.cs
+++ b/LMeter/Helpers/Extensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.Collections.Generic;
+using System.Numerics;
 
 namespace LMeter.Helpers
 {
@@ -40,6 +41,19 @@ namespace LMeter.Helpers
             }
 
             return new Vector4(red, green, blue, vec.W);
+        }
+
+        public static void MoveItem<T>(this List<T> list, int oldIndex, int newIndex)
+        {
+            if (oldIndex < 0 || newIndex < 0 || list.Count < oldIndex || list.Count < newIndex)
+            {
+                return;
+            }
+
+            var itemToMove = list[oldIndex];
+
+            list.RemoveAt(oldIndex);
+            list.Insert(newIndex, itemToMove);
         }
     }
 }

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -212,6 +212,8 @@ namespace LMeter.Meter
                 };
 
                 int currentIndex = 0;
+                var playerName = Singletons.Get<IClientState>().LocalPlayer?.Name.ToString() ?? "YOU";
+                
                 if (sortedCombatants.Count > this.BarConfig.BarCount)
                 {
                     currentIndex = Math.Clamp(_scrollPosition, 0, sortedCombatants.Count - this.BarConfig.BarCount);
@@ -219,7 +221,7 @@ namespace LMeter.Meter
 
                     if (this.BarConfig.AlwaysShowSelf)
                     {
-                        MovePlayerIntoViewableRange(sortedCombatants, _scrollPosition);
+                        MovePlayerIntoViewableRange(sortedCombatants, _scrollPosition, playerName);
                     }
                 }
 
@@ -228,7 +230,7 @@ namespace LMeter.Meter
                 {
                     Combatant combatant = sortedCombatants[currentIndex];
                     combatant.Rank = (currentIndex + 1).ToString();
-                    UpdatePlayerName(combatant);
+                    UpdatePlayerName(combatant, playerName);
 
                     float current = this.GeneralConfig.DataType switch
                     {
@@ -245,10 +247,8 @@ namespace LMeter.Meter
             }
         }
 
-        private void MovePlayerIntoViewableRange(List<Combatant> sortedCombatants, int scrollPosition)
+        private void MovePlayerIntoViewableRange(List<Combatant> sortedCombatants, int scrollPosition, string playerName)
         {
-            var playerName = Singletons.Get<IClientState>().LocalPlayer?.Name.ToString() ?? "YOU";
-
             var oldPlayerIndex = sortedCombatants.FindIndex(combatant => combatant.Name.Contains("YOU") || combatant.Name.Contains(playerName));
             if (oldPlayerIndex == -1)
             {
@@ -264,12 +264,11 @@ namespace LMeter.Meter
             sortedCombatants.MoveItem(oldPlayerIndex, newPlayerIndex);
         }
         
-        private void UpdatePlayerName(Combatant combatant)
+        private void UpdatePlayerName(Combatant combatant, string localPlayerName)
         {
-            var playerName = Singletons.Get<IClientState>().LocalPlayer?.Name.ToString() ?? "YOU";
             combatant.NameOverwrite = this.BarConfig.UseCharacterName switch
             {
-                true when combatant.Name.Contains("YOU") => playerName,
+                true when combatant.Name.Contains("YOU") => localPlayerName,
                 false when combatant.NameOverwrite is not null => null,
                 _ => combatant.NameOverwrite
             };

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -199,7 +199,7 @@ namespace LMeter.Meter
         {                
             if (actEvent?.Combatants is not null && actEvent.Combatants.Any())
             {
-                // We don't want to corrupte the cache. The entire logic past this point mutates the sorted ACT combatants instead of using a rendering cache
+                // We don't want to corrupt the cache. The entire logic past this point mutates the sorted ACT combatants instead of using a rendering cache
                 // This has the issue that some settings can't behave properly and or don't update till the following combat update/fight
                 List<Combatant> sortedCombatants = this.GetSortedCombatants(actEvent, this.GeneralConfig.DataType).ToList();
                 

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using Dalamud.Plugin.Services;
 using ImGuiNET;
 using LMeter.Config;
 using LMeter.Helpers;
@@ -198,7 +199,9 @@ namespace LMeter.Meter
         {                
             if (actEvent?.Combatants is not null && actEvent.Combatants.Any())
             {
-                List<Combatant> sortedCombatants = this.GetSortedCombatants(actEvent, this.GeneralConfig.DataType);
+                // We don't want to corrupte the cache. The entire logic past this point mutates the sorted ACT combatants instead of using a rendering cache
+                // This has the issue that some settings can't behave properly and or don't update till the following combat update/fight
+                List<Combatant> sortedCombatants = this.GetSortedCombatants(actEvent, this.GeneralConfig.DataType).ToList();
                 
                 float top = this.GeneralConfig.DataType switch
                 {
@@ -208,18 +211,24 @@ namespace LMeter.Meter
                     _ => 0
                 };
 
-                int i = 0;
+                int currentIndex = 0;
                 if (sortedCombatants.Count > this.BarConfig.BarCount)
                 {
-                    i = Math.Clamp(_scrollPosition, 0, sortedCombatants.Count - this.BarConfig.BarCount);
-                    _scrollPosition = i;
+                    currentIndex = Math.Clamp(_scrollPosition, 0, sortedCombatants.Count - this.BarConfig.BarCount);
+                    _scrollPosition = currentIndex;
+
+                    if (this.BarConfig.AlwaysShowSelf)
+                    {
+                        MovePlayerIntoViewableRange(sortedCombatants, _scrollPosition);
+                    }
                 }
 
-                int maxIndex = Math.Min(i + this.BarConfig.BarCount, sortedCombatants.Count);
-                for (; i < maxIndex; i++)
+                int maxIndex = Math.Min(currentIndex + this.BarConfig.BarCount, sortedCombatants.Count);
+                for (; currentIndex < maxIndex; currentIndex++)
                 {
-                    Combatant combatant = sortedCombatants[i];
-                    combatant.Rank = (i + 1).ToString();
+                    Combatant combatant = sortedCombatants[currentIndex];
+                    combatant.Rank = (currentIndex + 1).ToString();
+                    UpdatePlayerName(combatant);
 
                     float current = this.GeneralConfig.DataType switch
                     {
@@ -234,6 +243,36 @@ namespace LMeter.Meter
                     localPos = this.BarConfig.DrawBar(drawList, localPos, size, combatant, jobColor, barColor, top, current);
                 }
             }
+        }
+
+        private void MovePlayerIntoViewableRange(List<Combatant> sortedCombatants, int scrollPosition)
+        {
+            var playerName = Singletons.Get<IClientState>().LocalPlayer?.Name.ToString() ?? "YOU";
+
+            var oldPlayerIndex = sortedCombatants.FindIndex(combatant => combatant.Name.Contains("YOU") || combatant.Name.Contains(playerName));
+            if (oldPlayerIndex == -1)
+            {
+                return;
+            }
+
+            var newPlayerIndex = Math.Clamp(oldPlayerIndex, scrollPosition, this.BarConfig.BarCount + scrollPosition - 1);
+
+            if (oldPlayerIndex == newPlayerIndex)
+            {
+                return;
+            }
+            sortedCombatants.MoveItem(oldPlayerIndex, newPlayerIndex);
+        }
+        
+        private void UpdatePlayerName(Combatant combatant)
+        {
+            var playerName = Singletons.Get<IClientState>().LocalPlayer?.Name.ToString() ?? "YOU";
+            combatant.NameOverwrite = this.BarConfig.UseCharacterName switch
+            {
+                true when combatant.Name.Contains("YOU") => playerName,
+                false when combatant.NameOverwrite is not null => null,
+                _ => combatant.NameOverwrite
+            };
         }
         
         private bool DrawContextMenu(string popupId, out int selectedIndex)


### PR DESCRIPTION
This merge accomplishes 2 front facing things and a few more backend related things:
- Added the option to always show your own bar even if you are outside of the view range (clamps to top or bottom bar).
- Made it so that we do not overwrite the name in our cache which makes us unable to have a responsive design process.

Now some more information as to what was involved in adding these things:
We were using our source of truth (will be refered to as SoT) as a cache point which is fine in essence *nothing was changed here* but it creates the issue that if we mutate the returned cached list/objects our SoT will be corrupted.
This wasn't bad with the initial feature set *aside from a single point, more on that in a bit* but if we want to make changes into how we render said information without corrupting the SoT would be relatively impossible.
This is alleviated by creating a copy of the list when we grab the cached source of truth and using that for all our render specific changes.
The downside to this is that we don't create a deep copy so all the objects inside of the list will still be able to be corrupted but for this change I found that we can postpone fixing that until absolutely necessary to fix.

The other thing we had to change was the combatants data. We were overwriting the combatants SoT `Name` field inside of a Draw method (this is all kinds of bad but I digress). To alleviate this I moved the Name field's deserialization to a backing field named `OriginalName` and creating a new field `NameOverwrite` and a new property `Name` to replace our lost field, the property is an expression body that returns the overwrite to the name or the original name. The original name being our SoT and being forwarded to us from ACT.

Now that had a ripple effect of not working due to our Tag system only supporting fields, I have changed our Tag system to support both Fields and Properties, so that maybe in the future we can use expression type properties instead of `LazyStrings`. `Lazystrings` in the current implementation showcase a big problem, namely there is no cache invalidation. This was out of scope to add for this PR so I left that as it was to begin with.