### PR TITLE
Out of bounds protection

### DIFF
--- a/LMeter/ACT/TextTagFormatter.cs
+++ b/LMeter/ACT/TextTagFormatter.cs
@@ -37,12 +37,12 @@ namespace LMeter.ACT
             string? value = null;
             string key = m.Groups[1].Value;
 
-            if (!_members.TryGetValue(key, out var fieldInfo))
+            if (!_members.TryGetValue(key, out MemberInfo? fieldInfo))
             {
                 return value ?? m.Value;
             }
             
-            var memberValue = fieldInfo?.MemberType switch
+            object? memberValue = fieldInfo?.MemberType switch
             {
                 MemberTypes.Field => ((FieldInfo)fieldInfo).GetValue(_source),
                 MemberTypes.Property => ((PropertyInfo)fieldInfo).GetValue(_source),

--- a/LMeter/Config/BarConfig.cs
+++ b/LMeter/Config/BarConfig.cs
@@ -275,7 +275,7 @@ namespace LMeter.Config
 
             using (FontsManager.PushFont(this.BarNameFontKey))
             {
-                var leftText = combatant.Name;
+                string leftText = combatant.Name;
                 if (!leftText.Contains("YOU"))
                 {
                     leftText = combatant.GetFormattedString($" {this.LeftTextFormat} ", this.ThousandsSeparators ? "N" : "F");

--- a/LMeter/Config/GeneralConfig.cs
+++ b/LMeter/Config/GeneralConfig.cs
@@ -96,8 +96,17 @@ namespace LMeter.Config
             if (ImGui.BeginChild($"##{this.Name}", new Vector2(size.X, size.Y), true))
             {
                 Vector2 screenSize = ImGui.GetMainViewport().Size;
-                ImGui.DragFloat2("Position", ref this._position, 1, -screenSize.X / 2, screenSize.X / 2);
-                ImGui.DragFloat2("Size", ref this._size, 1, 0, screenSize.Y);
+
+                // We have to manually calculate the width of the dragfloats, this is due to us wanting to emulate DragFloat2 but with 2 different boudaries
+                // Default of IMGUI is WindowWidth * 0.65f so we just cut that in half and play with the margins a bit
+                float width = ImGui.GetWindowWidth() * 0.325f;
+                ImGui.PushItemWidth(width - 1.5f);
+                ImGui.DragFloat("##X", ref this._position.X, 1, -screenSize.X / 2, screenSize.X / 2);
+                ImGui.SameLine(width + 2f);
+                ImGui.DragFloat("Position", ref this._position.Y, 1, -screenSize.Y / 2, screenSize.Y / 2);
+                ImGui.PopItemWidth();
+                
+                ImGui.DragFloat2("Size", ref this._size, 1, 0, screenSize.Y / 2);
                 ImGui.Checkbox("Lock", ref this._lock);
                 ImGui.Checkbox("Click Through", ref this._clickThrough);
                 ImGui.Checkbox("Preview", ref this._preview);

--- a/LMeter/Converters/Vector2JsonConverter.cs
+++ b/LMeter/Converters/Vector2JsonConverter.cs
@@ -14,7 +14,7 @@ public class Vector2JsonConverter : JsonConverter<Vector2>
             throw new JsonException();
         }
 
-        var result = new Vector2();
+        Vector2 result = new();
         while (reader.Read())
         {
             if (reader.TokenType == JsonTokenType.EndObject)
@@ -22,17 +22,17 @@ public class Vector2JsonConverter : JsonConverter<Vector2>
                 return result;
             }
 
-            var propertyName = reader.GetString();
+            string? propertyName = reader.GetString();
             reader.Read();
             // Purposefully chose to have the GetSingle() calls inside of the cases for maintainability
             switch (propertyName)
             {
                 case nameof(result.X):
-                    var x = reader.GetSingle();
+                    float x = reader.GetSingle();
                     result.X = x;
                     break;
                 case nameof(result.Y):
-                    var y = reader.GetSingle();
+                    float y = reader.GetSingle();
                     result.Y = y;
                     break;
             }

--- a/LMeter/Converters/Vector4JsonConverter.cs
+++ b/LMeter/Converters/Vector4JsonConverter.cs
@@ -14,7 +14,7 @@ public class Vector4JsonConverter : JsonConverter<Vector4>
             throw new JsonException();
         }
 
-        var result = new Vector4();
+        Vector4 result = new Vector4();
         while (reader.Read())
         {
             if (reader.TokenType == JsonTokenType.EndObject)
@@ -22,25 +22,25 @@ public class Vector4JsonConverter : JsonConverter<Vector4>
                 return result;
             }
 
-            var propertyName = reader.GetString();
+            string? propertyName = reader.GetString();
             reader.Read();
             // Purposefully chose to have the GetSingle() calls inside of the cases for maintainability
             switch (propertyName)
             {
                 case nameof(result.X):
-                    var x = reader.GetSingle();
+                    float x = reader.GetSingle();
                     result.X = x;
                     break;
                 case nameof(result.Y):
-                    var y = reader.GetSingle();
+                    float y = reader.GetSingle();
                     result.Y = y;
                     break;
                 case nameof(result.Z):
-                    var z = reader.GetSingle();
+                    float z = reader.GetSingle();
                     result.Z = z;
                     break;
                 case nameof(result.W):
-                    var w = reader.GetSingle();
+                    float w = reader.GetSingle();
                     result.W = w;
                     break;
             }

--- a/LMeter/Helpers/CharacterState.cs
+++ b/LMeter/Helpers/CharacterState.cs
@@ -3,6 +3,7 @@ using Dalamud.Plugin.Services;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using System.Collections.Generic;
 using System.Linq;
+using Dalamud.Game.ClientState.Objects.SubKinds;
 using LMeter.Enums;
 
 namespace LMeter.Helpers
@@ -48,7 +49,7 @@ namespace LMeter.Helpers
 
         public static Job GetCharacterJob()
         {
-            var player = Singletons.Get<IClientState>().LocalPlayer;
+            PlayerCharacter? player = Singletons.Get<IClientState>().LocalPlayer;
             if (player is null)
             {
                 return Job.UKN;

--- a/LMeter/Helpers/ConfigHelpers.cs
+++ b/LMeter/Helpers/ConfigHelpers.cs
@@ -117,7 +117,7 @@ namespace LMeter.Helpers
                     // Temporary measure, should be removed after a while of having being ran in production.
                     // We have to remove the `$type` lines from the config otherwise we can't properly move to system.text.json
                     // On top of it being a massive potential security issue and it being an anti pattern
-                    var typeDefPattern = @"(^.*""\$type"": .*\n)";
+                    string typeDefPattern = @"(^.*""\$type"": .*\n)";
                     jsonString = Regex.Replace(jsonString, typeDefPattern, string.Empty, RegexOptions.Multiline | RegexOptions.Compiled);
                     
                     config = JsonSerializer.Deserialize<LMeterConfig>(jsonString, SerializerOptionsIndented);

--- a/LMeter/Helpers/Extensions.cs
+++ b/LMeter/Helpers/Extensions.cs
@@ -50,7 +50,7 @@ namespace LMeter.Helpers
                 return;
             }
 
-            var itemToMove = list[oldIndex];
+            T itemToMove = list[oldIndex];
 
             list.RemoveAt(oldIndex);
             list.Insert(newIndex, itemToMove);

--- a/LMeter/Helpers/FontsManager.cs
+++ b/LMeter/Helpers/FontsManager.cs
@@ -126,7 +126,7 @@ namespace LMeter.Helpers
                 return null;
             }
 
-            var builder = new ImFontGlyphRangesBuilderPtr(ImGuiNative.ImFontGlyphRangesBuilder_ImFontGlyphRangesBuilder());
+            ImFontGlyphRangesBuilderPtr builder = new ImFontGlyphRangesBuilderPtr(ImGuiNative.ImFontGlyphRangesBuilder_ImFontGlyphRangesBuilder());
 
             if (font.Chinese)
             {

--- a/LMeter/Helpers/TexturesCache.cs
+++ b/LMeter/Helpers/TexturesCache.cs
@@ -95,7 +95,7 @@ namespace LMeter.Helpers
         {
             if (disposing)
             {
-                foreach (var text in _desaturatedCache.Values)
+                foreach (IDalamudTextureWrap text in _desaturatedCache.Values)
                 {
                     text.Dispose();
                 }

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -108,6 +108,29 @@ namespace LMeter.Meter
             _lastFrameWasDragging = _hovered || _dragging;
         }
 
+        private static Vector2 GetPositionInsideBoundaries(Vector2 zeroPosition, Vector2 localPosition, Vector2 windowSize, Vector2 viewportSize)
+        {
+            if (localPosition.X + windowSize.X > viewportSize.X)
+            {
+                localPosition.X = zeroPosition.X + viewportSize.X - windowSize.X;
+            } 
+            else if (localPosition.X < -viewportSize.X)
+            {
+                localPosition.X = -viewportSize.X;
+            }
+
+            if (localPosition.Y + windowSize.Y > viewportSize.Y)
+            {
+                localPosition.Y = zeroPosition.Y + viewportSize.Y - windowSize.Y;
+            }
+            else if (localPosition.Y < -viewportSize.Y)
+            {
+                localPosition.Y = -viewportSize.Y;
+            }
+
+            return localPosition;
+        }
+
         public void Draw(Vector2 pos)
         {
             if (!this.GeneralConfig.Preview && !this.VisibilityConfig.IsVisible())
@@ -117,6 +140,9 @@ namespace LMeter.Meter
 
             Vector2 localPos = pos + this.GeneralConfig.Position;
             Vector2 size = this.GeneralConfig.Size;
+            Vector2 viewportSize = ImGui.GetMainViewport().Size;
+            
+            localPos = GetPositionInsideBoundaries(pos, localPos, size, viewportSize);
 
             if (ImGui.IsMouseHoveringRect(localPos, localPos + size))
             {

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -239,7 +239,7 @@ namespace LMeter.Meter
                 };
 
                 int currentIndex = 0;
-                var playerName = Singletons.Get<IClientState>().LocalPlayer?.Name.ToString() ?? "YOU";
+                string playerName = Singletons.Get<IClientState>().LocalPlayer?.Name.ToString() ?? "YOU";
                 
                 if (sortedCombatants.Count > this.BarConfig.BarCount)
                 {
@@ -276,13 +276,13 @@ namespace LMeter.Meter
 
         private void MovePlayerIntoViewableRange(List<Combatant> sortedCombatants, int scrollPosition, string playerName)
         {
-            var oldPlayerIndex = sortedCombatants.FindIndex(combatant => combatant.Name.Contains("YOU") || combatant.Name.Contains(playerName));
+            int oldPlayerIndex = sortedCombatants.FindIndex(combatant => combatant.Name.Contains("YOU") || combatant.Name.Contains(playerName));
             if (oldPlayerIndex == -1)
             {
                 return;
             }
 
-            var newPlayerIndex = Math.Clamp(oldPlayerIndex, scrollPosition, this.BarConfig.BarCount + scrollPosition - 1);
+            int newPlayerIndex = Math.Clamp(oldPlayerIndex, scrollPosition, this.BarConfig.BarCount + scrollPosition - 1);
 
             if (oldPlayerIndex == newPlayerIndex)
             {

--- a/LMeter/PluginManager.cs
+++ b/LMeter/PluginManager.cs
@@ -85,7 +85,7 @@ namespace LMeter
             ImGui.SetNextWindowSize(ImGui.GetMainViewport().Size);
             if (ImGui.Begin("LMeter_Root", _mainWindowFlags))
             {
-                foreach (var meter in _config.MeterList.Meters)
+                foreach (MeterWindow meter in _config.MeterList.Meters)
                 {
                     meter.Draw(_origin);
                 }
@@ -97,7 +97,7 @@ namespace LMeter
         public void Clear()
         {
             Singletons.Get<ACTClient>().Clear();
-            foreach (var meter in _config.MeterList.Meters)
+            foreach (MeterWindow meter in _config.MeterList.Meters)
             {
                 meter.Clear();
             }

--- a/LMeter/Windows/ConfigWindow.cs
+++ b/LMeter/Windows/ConfigWindow.cs
@@ -6,6 +6,7 @@ using Dalamud.Interface.Windowing;
 using ImGuiNET;
 using LMeter.Config;
 using LMeter.Helpers;
+using LMeter.Meter;
 
 namespace LMeter.Windows
 {
@@ -219,8 +220,8 @@ namespace LMeter.Windows
             ConfigHelpers.SaveConfig();
             _configStack.Clear();
 
-            var config = Singletons.Get<LMeterConfig>();
-            foreach (var meter in config.MeterList.Meters)
+            LMeterConfig config = Singletons.Get<LMeterConfig>();
+            foreach (MeterWindow meter in config.MeterList.Meters)
             {
                 meter.GeneralConfig.Preview = false;
             }


### PR DESCRIPTION
This adds guards to prevent people from positioning the meter out of screen.
Recently a lot of people have had issues where they imported a meter from others and because of different screen dimensions it then didn't appear and people thought the plugin was broken.
It should be prevented with a guard like this.
Keep in mind this is not the final version as I'm unsure yet if I want to make it a toggleable option to retain the old logic but I don't think many if any people run the meter off screen on purpose. And if they do I would like to know why.

This PR also changes some of the vars I introduced due to using the wrong profile on my editor and being used to writing code with a lot of vars.